### PR TITLE
Fix mac OS not recognized

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -17,7 +17,7 @@
 # description
 #   Determine the OS and version (if applicable).
 case $(uname) in
-  Darwin) OS='macOS' ;;
+  Darwin) OS='OSX' ;;
   CYGWIN_NT-*) OS='Windows' ;;
   FreeBSD|OpenBSD|DragonFly) OS='BSD' ;;
   Linux)
@@ -43,7 +43,7 @@ elif [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
 elif [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
   readonly TERMINAL="appleterm"
 else
-  if [[ "$OS" == "macOS" ]]; then
+  if [[ "$OS" == "OSX" ]]; then
     local termtest=$(ps -o 'command=' -p $(ps -o 'ppid=' -p $$) | tail -1 | awk '{print $NF}')
     # test if we are in a sudo su -
     if [[ $termtest == "-" || $termtest == "root" ]]; then
@@ -240,7 +240,7 @@ function getRelevantItem() {
 #   `sed` is unfortunately not consistent across OSes when it comes to flags.
 ##
 SED_EXTENDED_REGEX_PARAMETER="-r"
-if [[ "$OS" == 'macOS' ]]; then
+if [[ "$OS" == 'OSX' ]]; then
   local IS_BSD_SED="$(sed --version &>> /dev/null || echo "BSD sed")"
   if [[ -n "$IS_BSD_SED" ]]; then
     SED_EXTENDED_REGEX_PARAMETER="-E"

--- a/segments/battery.p9k
+++ b/segments/battery.p9k
@@ -38,7 +38,7 @@ prompt_battery() {
   # Set default values if the user did not configure them
   setDefault P9K_BATTERY_LOW_THRESHOLD  10
 
-  if [[ $OS =~ macOS && -f /usr/bin/pmset && -x /usr/bin/pmset ]]; then
+  if [[ $OS =~ "OSX" && -f /usr/bin/pmset && -x /usr/bin/pmset ]]; then
     # obtain battery information from system
     local raw_data="$(pmset -g batt | awk 'FNR==2{print}')"
     # return if there is no battery on system

--- a/segments/os_icon.p9k
+++ b/segments/os_icon.p9k
@@ -14,7 +14,7 @@
 # Parameters:
 #   name_of_icon  Generic  Flat/Awesome-Patched  Awesome-FontConfig  Awesome-Mapped-FontConfig  NerdFont
 case "$OS" in
-  "macOS")
+  "OSX")
     #                                                                                     
     registerIcon "APPLE_ICON"  'OSX'  $'\uE26E'  $'\uF179'  '\u'$CODEPOINT_OF_AWESOME_APPLE  $'\uF179'
     OS_ICON='APPLE_ICON'


### PR DESCRIPTION
This was due to an incomplete rename of "OSX" to "macOS".

Although I think that "macOS" is the better name, we should keep "OSX" for now. Should rename it in a separate PR.